### PR TITLE
Build as OSGI bundle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <name>${project.artifactId}</name>
     <description>Classes taken from Guava</description>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
 
     <url>http://github.com/davidmoten/guava-mini</url>
 
@@ -36,6 +36,7 @@
         <taglist.version>2.4</taglist.version>
         <m3.site.version>3.4</m3.site.version>
         <changelog.version>2.2</changelog.version>
+        <bundle.plugin.version>4.2.1</bundle.plugin.version>
         <coverage.reports.dir>${project.build.directory}/target/coverage-reports</coverage.reports.dir>
 
     </properties>
@@ -140,6 +141,17 @@
                             <exclude>com/github/davidmoten/guava-mini/ImageSaver.class</exclude>
                         </excludes>
                     </instrumentation>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>${bundle.plugin.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <obrRepository>NONE</obrRepository>
+                    <instructions>
+                    </instructions>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
As per my pull request for odata-client, this commit adds the OSGI metadata to the package manifest to aid deployment into OSGI environments.

Assuming you're happy with this, I'd like to bump the dependency in odata-client as well as removing the dependency on jcip-annotations which appears to be unused.  Once all this is done, odata-client and all its dependencies will be OSGI-friendly.